### PR TITLE
Call the right main function

### DIFF
--- a/jager.py
+++ b/jager.py
@@ -372,7 +372,7 @@ def test_main():
 
 if __name__ == "__main__":
     try:
-        test_main()
+        main()
     except KeyboardInterrupt:
         print "User aborted."
     except SystemExit:


### PR DESCRIPTION
Didn't notice we temporarily had a new `test_main()` function that causes `jager.py` not to pay attention to command-line parameters. :blush: 
