### PR TITLE
switched re_domain to re_fqdn

### DIFF
--- a/jager.py
+++ b/jager.py
@@ -148,8 +148,8 @@ def extract_domains(t):
     t = t.split("\n")
 
     for line in t:
-        hit = re.search(util.re_domain, line)
-        if re.search(util.re_domain, line):
+        hit = re.search(util.re_fqdn, line)
+        if re.search(util.re_fqdn, line):
             domains.append(hit.group().lower())
 
     domains = list(set(domains))


### PR DESCRIPTION
The regex in UtilityBelt switched names from `re_domain` :arrow_right:  `re_fqdn`. Better name change, but needed tweaked.
