### PR TITLE
MaxMind requires HTTPS for downloads

### DIFF
--- a/data/update_maxmind.sh
+++ b/data/update_maxmind.sh
@@ -7,6 +7,6 @@
 # caveat: if you do set this to update in an automated fashion, please uncomment the following line:
 # cd [combine_folder]/data/
 
-wget -q http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz && gunzip -f GeoIP.dat.gz
-wget -q http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz && gunzip -f GeoLiteCity.dat.gz
-wget -q http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum2.zip && unzip -qqo GeoIPASNum2.zip && rm GeoIPASNum2.zip
+wget -q https://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz && gunzip -f GeoIP.dat.gz
+wget -q https://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz && gunzip -f GeoLiteCity.dat.gz
+wget -q https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum2.zip && unzip -qqo GeoIPASNum2.zip && rm GeoIPASNum2.zip


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).